### PR TITLE
Add Bot Redis bootstrap foundation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,3 +32,6 @@ Local JSON file written by Bot before shutdown. Deleted after successful recover
 
 ## Player State
 Current playback snapshot: now playing track, position, volume, loop mode, queue list. Owned by Bot, replicated to Dashboard via Redis → NestJS → Socket.io.
+
+## Invalid Player State
+Player State that the Bot cannot safely publish because playback identity data is malformed. Examples include an invalid current track, a malformed queue, or queue items missing required identity such as track URI, source, or requester.

--- a/discordjs/package.json
+++ b/discordjs/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test -r ts-node/register \"test/**/*.test.ts\""
   },
   "keywords": [],
   "author": "",

--- a/discordjs/src/bot-bootstrap.ts
+++ b/discordjs/src/bot-bootstrap.ts
@@ -1,0 +1,151 @@
+import {
+  createGuildSettingsProvider,
+  type GuildSettings,
+  type GuildSettingsProvider,
+} from "./guild-settings";
+import { createRedisAdapter, type RedisAdapter, type RedisClientLike } from "./redis-adapter";
+import { createRedisLifecycle, type RedisLifecycle } from "./redis-lifecycle";
+import { detectRuntimeMode, type BotRuntimeMode, type RuntimeModeResult } from "./runtime-mode";
+import {
+  createStateRequestHandler,
+  type BotErrorPayload,
+  type PlayerState,
+  type RuntimeGuildState,
+  type StateRequestHandler,
+} from "./state-request-handler";
+
+const STATE_REQUEST_PATTERN = "backend:request:state:*";
+
+export interface BotBootstrap {
+  mode: BotRuntimeMode;
+  runtimeMode: RuntimeModeResult;
+  settingsProvider: GuildSettingsProvider;
+  lifecycle: RedisLifecycle;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+export interface BotBootstrapLogger {
+  debug?: (message: string, context?: Record<string, unknown>) => void;
+  warn?: (message: string, context?: Record<string, unknown>) => void;
+  error?: (message: string, context?: Record<string, unknown>) => void;
+}
+
+export interface CreateBotBootstrapOptions {
+  env: Partial<Pick<NodeJS.ProcessEnv, "REDIS_URL">>;
+  connectRedis: (redisUrl: string, signal: AbortSignal) => Promise<void>;
+  createRedisClient: (redisUrl: string) => RedisClientLike;
+  loadGuildSettingsFromSupabase: (guildId: string) => Promise<GuildSettings>;
+  loadGuildSettingsFromConnectedCache: (guildId: string) => Promise<GuildSettings>;
+  getRuntimeGuildState: (
+    guildId: string,
+  ) => Promise<RuntimeGuildState | null | undefined>;
+  getActiveGuildIds: () => string[];
+  nowIso: () => string;
+  redisConnectTimeoutMs?: number;
+  logger?: BotBootstrapLogger;
+}
+
+export async function createBotBootstrap(
+  options: CreateBotBootstrapOptions,
+): Promise<BotBootstrap> {
+  const runtimeMode = await detectRuntimeMode({
+    env: options.env,
+    connectRedis: options.connectRedis,
+    ...(options.redisConnectTimeoutMs === undefined
+      ? {}
+      : { timeoutMs: options.redisConnectTimeoutMs }),
+  });
+  const settingsProvider = createGuildSettingsProvider({
+    mode: runtimeMode.mode,
+    loadFromSupabase: options.loadGuildSettingsFromSupabase,
+    loadFromConnectedCache: options.loadGuildSettingsFromConnectedCache,
+  });
+
+  let adapter: RedisAdapter | null = null;
+  let lifecycle: RedisLifecycle;
+  let stateRequestHandler: StateRequestHandler;
+
+  const publishStateFull = async (
+    guildId: string,
+    state: PlayerState,
+  ): Promise<void> => {
+    await requireRedisAdapter(adapter).publish(`bot:${guildId}:state:full`, state);
+  };
+  const publishError = async (
+    guildId: string,
+    error: BotErrorPayload,
+  ): Promise<void> => {
+    await requireRedisAdapter(adapter).publish(`bot:${guildId}:error`, error);
+  };
+
+  stateRequestHandler = createStateRequestHandler({
+    mode: runtimeMode.mode,
+    getGuildSettings: settingsProvider.getGuildSettings,
+    getRuntimeGuildState: options.getRuntimeGuildState,
+    publishStateFull,
+    publishError,
+    nowIso: options.nowIso,
+    ...(options.logger ? { logger: options.logger } : {}),
+  });
+
+  if (runtimeMode.mode === "connected") {
+    const redisUrl = options.env.REDIS_URL;
+    if (!redisUrl) {
+      throw new Error("Connected Mode requires REDIS_URL");
+    }
+
+    adapter = createRedisAdapter({
+      redisUrl,
+      patterns: [STATE_REQUEST_PATTERN],
+      createClient: options.createRedisClient,
+      onMessage: async (channel, payload) => {
+        await stateRequestHandler.handleStateRequest(channel, payload);
+      },
+      onReconnect: async () => {
+        await lifecycle.handleReconnect();
+      },
+      ...(options.logger ? { logger: options.logger } : {}),
+    });
+  }
+
+  lifecycle = createRedisLifecycle({
+    mode: runtimeMode.mode,
+    startRedis: async () => {
+      await requireRedisAdapter(adapter).start();
+    },
+    getActiveGuildIds: options.getActiveGuildIds,
+    publishFullState: async (guildId) => {
+      const result = await stateRequestHandler.handleStateRequest(
+        `backend:request:state:${guildId}`,
+        { guildId },
+      );
+      if (!result.statePublished) {
+        throw new Error(`Failed to publish full PlayerState for Guild ${guildId}`);
+      }
+    },
+  });
+
+  return {
+    mode: runtimeMode.mode,
+    runtimeMode,
+    settingsProvider,
+    lifecycle,
+    async start(): Promise<void> {
+      await lifecycle.start();
+    },
+    async stop(): Promise<void> {
+      if (adapter) {
+        await adapter.stop();
+      }
+    },
+  };
+}
+
+function requireRedisAdapter(adapter: RedisAdapter | null): RedisAdapter {
+  if (!adapter) {
+    throw new Error("Redis adapter is unavailable in Standalone Mode");
+  }
+
+  return adapter;
+}

--- a/discordjs/src/guild-settings.ts
+++ b/discordjs/src/guild-settings.ts
@@ -1,0 +1,40 @@
+import type { BotRuntimeMode } from "./runtime-mode";
+
+export interface GuildSettings {
+  guildId: string;
+  musicChannelId: string | null;
+  volumeLimit: number;
+}
+
+export interface GuildSettingsProvider {
+  getGuildSettings(guildId: string): Promise<GuildSettings>;
+}
+
+export interface CreateGuildSettingsProviderOptions {
+  mode: BotRuntimeMode;
+  loadFromSupabase: (guildId: string) => Promise<GuildSettings>;
+  loadFromConnectedCache: (guildId: string) => Promise<GuildSettings>;
+}
+
+export function createGuildSettingsProvider(
+  options: CreateGuildSettingsProviderOptions,
+): GuildSettingsProvider {
+  const standaloneCache = new Map<string, GuildSettings>();
+
+  return {
+    async getGuildSettings(guildId: string): Promise<GuildSettings> {
+      if (options.mode === "connected") {
+        return options.loadFromConnectedCache(guildId);
+      }
+
+      const cached = standaloneCache.get(guildId);
+      if (cached) {
+        return cached;
+      }
+
+      const settings = await options.loadFromSupabase(guildId);
+      standaloneCache.set(guildId, settings);
+      return settings;
+    },
+  };
+}

--- a/discordjs/src/redis-adapter.ts
+++ b/discordjs/src/redis-adapter.ts
@@ -1,0 +1,279 @@
+export interface RedisClientLike {
+  psubscribe(...patterns: string[]): Promise<unknown>;
+  publish(channel: string, message: string): Promise<unknown>;
+  quit(): Promise<unknown>;
+  on(event: string, callback: (...args: unknown[]) => void): this;
+}
+
+export interface RedisAdapter {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  publish(channel: string, payload: unknown): Promise<void>;
+}
+
+export interface RedisAdapterLogger {
+  debug?: (message: string, context?: Record<string, unknown>) => void;
+  warn?: (message: string, context?: Record<string, unknown>) => void;
+  error?: (message: string, context?: Record<string, unknown>) => void;
+}
+
+export interface CreateRedisAdapterOptions {
+  redisUrl: string;
+  patterns: string[];
+  createClient: (redisUrl: string) => RedisClientLike;
+  onMessage: (channel: string, payload: unknown) => Promise<void> | void;
+  onReconnect: () => Promise<void> | void;
+  logger?: RedisAdapterLogger;
+}
+
+export function createRedisAdapter(
+  options: CreateRedisAdapterOptions,
+): RedisAdapter {
+  let subscriber: RedisClientLike | null = null;
+  let publisher: RedisClientLike | null = null;
+  let started = false;
+  let stopped = false;
+  let subscriberReady = false;
+  let publisherReady = false;
+  let initialReadyComplete = false;
+  let disconnectedAfterReady = false;
+  let activeGeneration = 0;
+
+  return {
+    async start(): Promise<void> {
+      if (options.patterns.length === 0) {
+        throw new Error("Redis adapter requires at least one subscription pattern");
+      }
+
+      if (started) {
+        return;
+      }
+
+      subscriber = options.createClient(options.redisUrl);
+      publisher = options.createClient(options.redisUrl);
+      activeGeneration += 1;
+      const generation = activeGeneration;
+      subscriber.on("pmessage", (_pattern, channel, message) => {
+        if (stopped || generation !== activeGeneration) {
+          return;
+        }
+
+        void handleMessage(options, String(channel), String(message));
+      });
+      subscriber.on("ready", () => {
+        if (generation !== activeGeneration) {
+          return;
+        }
+
+        subscriberReady = true;
+        void maybeHandleReconnect(options, {
+          stopped,
+          subscriberReady,
+          publisherReady,
+          initialReadyComplete,
+          disconnectedAfterReady,
+          markInitialReadyComplete: () => {
+            initialReadyComplete = true;
+          },
+          markReconnectHandled: () => {
+            disconnectedAfterReady = false;
+          },
+        });
+      });
+      publisher.on("ready", () => {
+        if (generation !== activeGeneration) {
+          return;
+        }
+
+        publisherReady = true;
+        void maybeHandleReconnect(options, {
+          stopped,
+          subscriberReady,
+          publisherReady,
+          initialReadyComplete,
+          disconnectedAfterReady,
+          markInitialReadyComplete: () => {
+            initialReadyComplete = true;
+          },
+          markReconnectHandled: () => {
+            disconnectedAfterReady = false;
+          },
+        });
+      });
+      const markDisconnected = () => {
+        if (generation !== activeGeneration) {
+          return;
+        }
+
+        if (initialReadyComplete) {
+          disconnectedAfterReady = true;
+        }
+      };
+      subscriber.on("close", () => {
+        subscriberReady = false;
+        markDisconnected();
+      });
+      subscriber.on("end", () => {
+        subscriberReady = false;
+        markDisconnected();
+      });
+      publisher.on("close", () => {
+        publisherReady = false;
+        markDisconnected();
+      });
+      publisher.on("end", () => {
+        publisherReady = false;
+        markDisconnected();
+      });
+      subscriber.on("error", (error) => {
+        logRedisClientError(options, "subscriber", error);
+      });
+      publisher.on("error", (error) => {
+        logRedisClientError(options, "publisher", error);
+      });
+      started = true;
+      stopped = false;
+      try {
+        await subscriber.psubscribe(...options.patterns);
+      } catch (error) {
+        activeGeneration += 1;
+        const clients = [subscriber, publisher].filter(
+          (client): client is RedisClientLike => client !== null,
+        );
+        await Promise.allSettled(clients.map((client) => client.quit()));
+        subscriber = null;
+        publisher = null;
+        started = false;
+        stopped = false;
+        subscriberReady = false;
+        publisherReady = false;
+        initialReadyComplete = false;
+        disconnectedAfterReady = false;
+        throw error;
+      }
+    },
+
+    async stop(): Promise<void> {
+      if (!started) {
+        return;
+      }
+
+      if (stopped) {
+        return;
+      }
+
+      stopped = true;
+      activeGeneration += 1;
+      const clients = [subscriber, publisher].filter(
+        (client): client is RedisClientLike => client !== null,
+      );
+      const stopErrors: unknown[] = [];
+
+      for (const client of clients) {
+        try {
+          await client.quit();
+        } catch (error) {
+          stopErrors.push(error);
+          options.logger?.error?.("Redis client quit failed", {
+            errorMessage: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      if (stopErrors.length > 0) {
+        throw new Error("Redis adapter failed to stop cleanly");
+      }
+
+      subscriber = null;
+      publisher = null;
+      started = false;
+      subscriberReady = false;
+      publisherReady = false;
+      initialReadyComplete = false;
+      disconnectedAfterReady = false;
+    },
+
+    async publish(channel: string, payload: unknown): Promise<void> {
+      if (stopped) {
+        throw new Error("Redis adapter has been stopped");
+      }
+
+      if (!started || !publisher) {
+        throw new Error("Redis adapter has not started");
+      }
+
+      await publisher.publish(channel, JSON.stringify(payload ?? {}));
+    },
+  };
+}
+
+function logRedisClientError(
+  options: CreateRedisAdapterOptions,
+  clientRole: "subscriber" | "publisher",
+  error: unknown,
+): void {
+  options.logger?.error?.("Redis client error", {
+    clientRole,
+    errorMessage: error instanceof Error ? error.message : String(error),
+  });
+}
+
+interface ReconnectState {
+  stopped: boolean;
+  subscriberReady: boolean;
+  publisherReady: boolean;
+  initialReadyComplete: boolean;
+  disconnectedAfterReady: boolean;
+  markInitialReadyComplete: () => void;
+  markReconnectHandled: () => void;
+}
+
+async function maybeHandleReconnect(
+  options: CreateRedisAdapterOptions,
+  state: ReconnectState,
+): Promise<void> {
+  if (state.stopped || !state.subscriberReady || !state.publisherReady) {
+    return;
+  }
+
+  if (!state.initialReadyComplete) {
+    state.markInitialReadyComplete();
+    return;
+  }
+
+  if (!state.disconnectedAfterReady) {
+    return;
+  }
+
+  state.markReconnectHandled();
+  try {
+    await options.onReconnect();
+  } catch (error) {
+    options.logger?.error?.("Redis reconnect handler failed", {
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleMessage(
+  options: CreateRedisAdapterOptions,
+  channel: string,
+  message: string,
+): Promise<void> {
+  try {
+    await options.onMessage(channel, parseMessage(message));
+  } catch (error) {
+    options.logger?.error?.("Redis message handler failed", {
+      channel,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function parseMessage(message: string): unknown {
+  try {
+    return JSON.parse(message);
+  } catch {
+    return message;
+  }
+}

--- a/discordjs/src/redis-lifecycle.ts
+++ b/discordjs/src/redis-lifecycle.ts
@@ -1,0 +1,52 @@
+import type { BotRuntimeMode } from "./runtime-mode";
+
+export interface RedisLifecycle {
+  start(): Promise<void>;
+  handleReconnect(): Promise<RedisReconnectResult>;
+  getMode(): BotRuntimeMode;
+}
+
+export interface RedisReconnectResult {
+  failedGuildIds: string[];
+}
+
+export interface CreateRedisLifecycleOptions {
+  mode: BotRuntimeMode;
+  startRedis: () => Promise<void>;
+  getActiveGuildIds: () => string[];
+  publishFullState: (guildId: string) => Promise<void>;
+}
+
+export function createRedisLifecycle(
+  options: CreateRedisLifecycleOptions,
+): RedisLifecycle {
+  return {
+    async start(): Promise<void> {
+      if (options.mode === "connected") {
+        await options.startRedis();
+      }
+    },
+
+    async handleReconnect(): Promise<RedisReconnectResult> {
+      const failedGuildIds: string[] = [];
+
+      if (options.mode !== "connected") {
+        return { failedGuildIds };
+      }
+
+      for (const guildId of options.getActiveGuildIds()) {
+        try {
+          await options.publishFullState(guildId);
+        } catch {
+          failedGuildIds.push(guildId);
+        }
+      }
+
+      return { failedGuildIds };
+    },
+
+    getMode(): BotRuntimeMode {
+      return options.mode;
+    },
+  };
+}

--- a/discordjs/src/runtime-mode.ts
+++ b/discordjs/src/runtime-mode.ts
@@ -1,0 +1,70 @@
+export type BotRuntimeMode = "connected" | "standalone";
+
+export type RuntimeModeReason =
+  | "redis_connected"
+  | "redis_url_missing"
+  | "redis_unavailable";
+
+export interface RuntimeModeResult {
+  mode: BotRuntimeMode;
+  reason: RuntimeModeReason;
+}
+
+export interface DetectRuntimeModeOptions {
+  env: Partial<Pick<NodeJS.ProcessEnv, "REDIS_URL">>;
+  connectRedis: (redisUrl: string, signal: AbortSignal) => Promise<void>;
+  timeoutMs?: number;
+}
+
+export async function detectRuntimeMode(
+  options: DetectRuntimeModeOptions,
+): Promise<RuntimeModeResult> {
+  const redisUrl = options.env.REDIS_URL;
+
+  if (!redisUrl) {
+    return {
+      mode: "standalone",
+      reason: "redis_url_missing",
+    };
+  }
+
+  const timeoutMs = options.timeoutMs ?? 3000;
+  const abortController = new AbortController();
+
+  try {
+    await withTimeout(
+      options.connectRedis(redisUrl, abortController.signal),
+      timeoutMs,
+      abortController,
+    );
+  } catch {
+    return {
+      mode: "standalone",
+      reason: "redis_unavailable",
+    };
+  }
+
+  return {
+    mode: "connected",
+    reason: "redis_connected",
+  };
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  abortController: AbortController,
+): Promise<T> {
+  let timeout: NodeJS.Timeout;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      abortController.abort();
+      reject(new Error(`Redis connection timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    clearTimeout(timeout);
+  });
+}

--- a/discordjs/src/state-request-handler.ts
+++ b/discordjs/src/state-request-handler.ts
@@ -1,0 +1,390 @@
+import type { GuildSettings } from "./guild-settings";
+import type { BotRuntimeMode } from "./runtime-mode";
+
+export interface Track {
+  uri: string;
+  title: string;
+  artist: string;
+  thumbnailUrl: string;
+  durationMs: number;
+  source: "youtube" | "spotify" | "soundcloud";
+  requesterId: string;
+}
+
+export interface PlayerState {
+  guildId: string;
+  botMode: "connected";
+  isPlaying: boolean;
+  isPaused: boolean;
+  volume: number;
+  loopMode: "off" | "track" | "queue";
+  position: number;
+  currentTrack: Track | null;
+  queue: Track[];
+  voiceChannelId: string | null;
+}
+
+export interface BotErrorPayload {
+  errorType:
+    | "invalid_payload"
+    | "command_failed"
+    | "lavalink_error"
+    | "settings_error";
+  message: string;
+  source: "redis" | "discord" | "lavalink" | "supabase";
+  action?: string;
+  guildId: string;
+  timestamp: string;
+}
+
+export interface RuntimeGuildState {
+  currentTrack?: unknown;
+  queue?: unknown;
+  volume?: unknown;
+  loopMode?: unknown;
+  position?: unknown;
+  isPaused?: unknown;
+  voiceChannelId?: unknown;
+}
+
+export interface StateRequestHandler {
+  handleStateRequest(
+    channel: string,
+    payload: unknown,
+  ): Promise<StateRequestResult>;
+}
+
+export interface StateRequestResult {
+  statePublished: boolean;
+}
+
+export interface StateRequestLogger {
+  debug?: (message: string, context?: Record<string, unknown>) => void;
+  warn?: (message: string, context?: Record<string, unknown>) => void;
+  error?: (message: string, context?: Record<string, unknown>) => void;
+}
+
+export interface CreateStateRequestHandlerOptions {
+  mode: BotRuntimeMode;
+  getGuildSettings: (guildId: string) => Promise<GuildSettings>;
+  getRuntimeGuildState: (
+    guildId: string,
+  ) => Promise<RuntimeGuildState | null | undefined>;
+  publishStateFull: (guildId: string, state: PlayerState) => Promise<void>;
+  publishError: (guildId: string, error: BotErrorPayload) => Promise<void>;
+  nowIso: () => string;
+  logger?: StateRequestLogger;
+}
+
+const STATE_REQUEST_CHANNEL_PREFIX = "backend:request:state:";
+
+export function createStateRequestHandler(
+  options: CreateStateRequestHandlerOptions,
+): StateRequestHandler {
+  return {
+    async handleStateRequest(
+      channel: string,
+      payload: unknown,
+    ): Promise<StateRequestResult> {
+      if (options.mode !== "connected") {
+        return { statePublished: false };
+      }
+
+      const guildId = parseStateRequestGuildId(channel);
+      if (!guildId) {
+        options.logger?.warn?.("Ignoring invalid state request channel", {
+          channel,
+        });
+        return { statePublished: false };
+      }
+
+      if (!isValidStateRequestPayload(payload, guildId)) {
+        await options.publishError(guildId, {
+          errorType: "invalid_payload",
+          message: "Invalid state request payload",
+          source: "redis",
+          action: "state:full",
+          guildId,
+          timestamp: options.nowIso(),
+        });
+        return { statePublished: false };
+      }
+
+      const settingsResult = await getSettingsOrDefault(options, guildId);
+      const runtimeState = await getRuntimeStateOrError(options, guildId);
+      if (runtimeState.failed) {
+        await options.publishError(guildId, {
+          errorType: "command_failed",
+          message: "Failed to build PlayerState",
+          source: "redis",
+          action: "state:full",
+          guildId,
+          timestamp: options.nowIso(),
+        });
+        return { statePublished: false };
+      }
+
+      const state = tryBuildPlayerState(
+        guildId,
+        settingsResult.settings,
+        runtimeState.state,
+      );
+      if (!state) {
+        await options.publishError(guildId, {
+          errorType: "invalid_payload",
+          message: "Invalid PlayerState",
+          source: "redis",
+          action: "state:full",
+          guildId,
+          timestamp: options.nowIso(),
+        });
+        return { statePublished: false };
+      }
+
+      try {
+        await options.publishStateFull(guildId, state);
+      } catch (error) {
+        options.logger?.warn?.("Failed to publish full PlayerState", {
+          guildId,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+        return { statePublished: false };
+      }
+
+      if (settingsResult.failed) {
+        await options.publishError(guildId, {
+          errorType: "settings_error",
+          message: "Failed to load Guild settings",
+          source: "supabase",
+          action: "state:full",
+          guildId,
+          timestamp: options.nowIso(),
+        });
+      }
+
+      return { statePublished: true };
+    },
+  };
+}
+
+async function getRuntimeStateOrError(
+  options: CreateStateRequestHandlerOptions,
+  guildId: string,
+): Promise<
+  | { failed: false; state: RuntimeGuildState | null | undefined }
+  | { failed: true }
+> {
+  try {
+    return {
+      failed: false,
+      state: await options.getRuntimeGuildState(guildId),
+    };
+  } catch {
+    options.logger?.error?.("Failed to read runtime Guild state", { guildId });
+    return { failed: true };
+  }
+}
+
+async function getSettingsOrDefault(
+  options: CreateStateRequestHandlerOptions,
+  guildId: string,
+): Promise<{ settings: GuildSettings; failed: boolean }> {
+  try {
+    return {
+      settings: await options.getGuildSettings(guildId),
+      failed: false,
+    };
+  } catch {
+    options.logger?.warn?.("Failed to load Guild settings", { guildId });
+    return {
+      settings: {
+        guildId,
+        musicChannelId: null,
+        volumeLimit: 100,
+      },
+      failed: true,
+    };
+  }
+}
+
+function tryBuildPlayerState(
+  guildId: string,
+  settings: GuildSettings,
+  runtimeState: RuntimeGuildState | null | undefined,
+): PlayerState | null {
+  try {
+    return buildPlayerState(guildId, settings, runtimeState);
+  } catch {
+    return null;
+  }
+}
+
+function isValidStateRequestPayload(
+  payload: unknown,
+  channelGuildId: string,
+): boolean {
+  if (payload === undefined || payload === null) {
+    return true;
+  }
+
+  if (
+    typeof payload !== "object" ||
+    Array.isArray(payload)
+  ) {
+    return false;
+  }
+
+  if (!("guildId" in payload)) {
+    return true;
+  }
+
+  return payload.guildId === channelGuildId;
+}
+
+function parseStateRequestGuildId(channel: string): string | null {
+  if (!channel.startsWith(STATE_REQUEST_CHANNEL_PREFIX)) {
+    return null;
+  }
+
+  const guildId = channel.slice(STATE_REQUEST_CHANNEL_PREFIX.length).trim();
+  return guildId.length > 0 ? guildId : null;
+}
+
+function buildPlayerState(
+  guildId: string,
+  settings: GuildSettings,
+  runtimeState: RuntimeGuildState | null | undefined,
+): PlayerState {
+  const volumeLimit = normalizeVolumeLimit(settings.volumeLimit);
+  const currentTrack = normalizeOptionalTrack(runtimeState?.currentTrack);
+  const queue = normalizeQueue(runtimeState?.queue);
+  const position = normalizePosition(runtimeState?.position, currentTrack);
+
+  return {
+    guildId,
+    botMode: "connected",
+    isPlaying: currentTrack !== null,
+    isPaused: currentTrack !== null && runtimeState?.isPaused === true,
+    volume: normalizeVolume(runtimeState?.volume, volumeLimit),
+    loopMode: normalizeLoopMode(runtimeState?.loopMode),
+    position,
+    currentTrack,
+    queue,
+    voiceChannelId: normalizeVoiceChannelId(runtimeState?.voiceChannelId),
+  };
+}
+
+function normalizeVolumeLimit(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 100;
+  }
+
+  return Math.min(Math.max(value, 0), 100);
+}
+
+function normalizeVolume(value: unknown, volumeLimit: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return Math.min(100, volumeLimit);
+  }
+
+  return Math.min(Math.max(value, 0), volumeLimit);
+}
+
+function normalizeLoopMode(value: unknown): PlayerState["loopMode"] {
+  return value === "track" || value === "queue" ? value : "off";
+}
+
+function normalizePosition(value: unknown, currentTrack: Track | null): number {
+  if (!currentTrack || currentTrack.durationMs <= 0) {
+    return 0;
+  }
+
+  const position = typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return Math.min(Math.max(position, 0), currentTrack.durationMs);
+}
+
+function normalizeVoiceChannelId(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : null;
+}
+
+function normalizeQueue(value: unknown): Track[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error("Invalid queue");
+  }
+
+  return value.map((item) => normalizeRequiredTrack(item));
+}
+
+function normalizeOptionalTrack(value: unknown): Track | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  return normalizeRequiredTrack(value);
+}
+
+function normalizeRequiredTrack(value: unknown): Track {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Track");
+  }
+
+  const uri = requiredString(value.uri);
+  const requesterId = requiredString(value.requesterId);
+
+  return {
+    uri,
+    title: displayString(value.title, "Unknown title"),
+    artist: displayString(value.artist, "Unknown artist"),
+    thumbnailUrl: optionalString(value.thumbnailUrl),
+    durationMs: normalizeDurationMs(value.durationMs),
+    source: normalizeSource(value.source),
+    requesterId,
+  };
+}
+
+function normalizeSource(value: unknown): Track["source"] {
+  if (typeof value !== "string") {
+    throw new Error("Invalid Track source");
+  }
+
+  const source = value.toLowerCase();
+  if (source === "youtube" || source === "spotify" || source === "soundcloud") {
+    return source;
+  }
+
+  throw new Error("Invalid Track source");
+}
+
+function normalizeDurationMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+
+  return value;
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("Required string is missing");
+  }
+
+  return value;
+}
+
+function displayString(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim().length > 0 ? value : fallback;
+}
+
+function optionalString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/discordjs/test/bot-bootstrap.test.ts
+++ b/discordjs/test/bot-bootstrap.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setImmediate } from "node:timers/promises";
+
+import { createBotBootstrap } from "../src/bot-bootstrap";
+import type { RedisClientLike } from "../src/redis-adapter";
+
+test("Standalone Mode starts without Redis and loads settings from Supabase provider", async () => {
+  let redisClients = 0;
+  let supabaseLoads = 0;
+  const bootstrap = await createBotBootstrap({
+    env: {},
+    connectRedis: async () => {
+      throw new Error("Redis should not be checked without REDIS_URL");
+    },
+    createRedisClient: () => {
+      redisClients += 1;
+      return new FakeRedisClient();
+    },
+    loadGuildSettingsFromSupabase: async (guildId) => {
+      supabaseLoads += 1;
+      return {
+        guildId,
+        musicChannelId: "music-1",
+        volumeLimit: 70,
+      };
+    },
+    loadGuildSettingsFromConnectedCache: async () => {
+      throw new Error("Connected settings cache should not be used");
+    },
+    getRuntimeGuildState: async () => undefined,
+    getActiveGuildIds: () => ["guild-1"],
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await bootstrap.start();
+  const settings = await bootstrap.settingsProvider.getGuildSettings("guild-1");
+
+  assert.equal(bootstrap.mode, "standalone");
+  assert.equal(redisClients, 0);
+  assert.equal(supabaseLoads, 1);
+  assert.deepEqual(settings, {
+    guildId: "guild-1",
+    musicChannelId: "music-1",
+    volumeLimit: 70,
+  });
+});
+
+test("Connected Mode subscribes state requests and publishes full PlayerState", async () => {
+  const clients: FakeRedisClient[] = [];
+  const bootstrap = await createBotBootstrap({
+    env: { REDIS_URL: "redis://localhost:6379" },
+    connectRedis: async () => {},
+    createRedisClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    loadGuildSettingsFromSupabase: async () => {
+      throw new Error("Supabase settings should not be used in Connected Mode");
+    },
+    loadGuildSettingsFromConnectedCache: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 55,
+    }),
+    getRuntimeGuildState: async () => ({
+      currentTrack: {
+        uri: "https://example.test/current",
+        title: "Current",
+        artist: "Artist",
+        thumbnailUrl: "https://example.test/thumb.jpg",
+        durationMs: 120_000,
+        source: "youtube",
+        requesterId: "discord-user-1",
+      },
+      queue: [],
+      volume: 80,
+    }),
+    getActiveGuildIds: () => [],
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await bootstrap.start();
+  clients[0]?.emit(
+    "pmessage",
+    "backend:request:state:*",
+    "backend:request:state:guild-1",
+    "{}",
+  );
+  await flushRedisCallbacks();
+
+  assert.equal(bootstrap.mode, "connected");
+  assert.deepEqual(clients[0]?.psubscribeCalls, [["backend:request:state:*"]]);
+  assert.deepEqual(clients[1]?.publishCalls, [
+    [
+      "bot:guild-1:state:full",
+      JSON.stringify({
+        guildId: "guild-1",
+        botMode: "connected",
+        isPlaying: true,
+        isPaused: false,
+        volume: 55,
+        loopMode: "off",
+        position: 0,
+        currentTrack: {
+          uri: "https://example.test/current",
+          title: "Current",
+          artist: "Artist",
+          thumbnailUrl: "https://example.test/thumb.jpg",
+          durationMs: 120_000,
+          source: "youtube",
+          requesterId: "discord-user-1",
+        },
+        queue: [],
+        voiceChannelId: null,
+      }),
+    ],
+  ]);
+});
+
+test("Connected Mode Redis reconnect publishes full state for active Guilds", async () => {
+  const clients: FakeRedisClient[] = [];
+  const bootstrap = await createBotBootstrap({
+    env: { REDIS_URL: "redis://localhost:6379" },
+    connectRedis: async () => {},
+    createRedisClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    loadGuildSettingsFromSupabase: async () => {
+      throw new Error("Supabase settings should not be used in Connected Mode");
+    },
+    loadGuildSettingsFromConnectedCache: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 100,
+    }),
+    getRuntimeGuildState: async () => undefined,
+    getActiveGuildIds: () => ["guild-1", "guild-2"],
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await bootstrap.start();
+  clients[0]?.emit("ready");
+  clients[1]?.emit("ready");
+  clients[0]?.emit("close");
+  clients[1]?.emit("ready");
+  clients[0]?.emit("ready");
+  await flushRedisCallbacks();
+
+  assert.deepEqual(
+    clients[1]?.publishCalls.map(([channel]) => channel),
+    ["bot:guild-1:state:full", "bot:guild-2:state:full"],
+  );
+});
+
+test("Connected Mode Redis reconnect reports active Guilds whose full state cannot be published", async () => {
+  const clients: FakeRedisClient[] = [];
+  const bootstrap = await createBotBootstrap({
+    env: { REDIS_URL: "redis://localhost:6379" },
+    connectRedis: async () => {},
+    createRedisClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    loadGuildSettingsFromSupabase: async () => {
+      throw new Error("Supabase settings should not be used in Connected Mode");
+    },
+    loadGuildSettingsFromConnectedCache: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 100,
+    }),
+    getRuntimeGuildState: async () => undefined,
+    getActiveGuildIds: () => ["guild-1", "guild-2"],
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await bootstrap.start();
+  clients[1]!.publishFailures.add("bot:guild-1:state:full");
+
+  const result = await bootstrap.lifecycle.handleReconnect();
+
+  assert.deepEqual(result.failedGuildIds, ["guild-1"]);
+  assert.deepEqual(
+    clients[1]?.publishCalls.map(([channel]) => channel),
+    ["bot:guild-1:state:full", "bot:guild-2:state:full"],
+  );
+});
+
+class FakeRedisClient implements RedisClientLike {
+  psubscribeCalls: string[][] = [];
+  publishCalls: Array<[string, string]> = [];
+  quitCalls = 0;
+  publishFailures = new Set<string>();
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  async psubscribe(...patterns: string[]): Promise<unknown> {
+    this.psubscribeCalls.push(patterns);
+    return undefined;
+  }
+
+  async publish(channel: string, message: string): Promise<unknown> {
+    this.publishCalls.push([channel, message]);
+    if (this.publishFailures.has(channel)) {
+      throw new Error(`publish failed for ${channel}`);
+    }
+
+    return undefined;
+  }
+
+  async quit(): Promise<unknown> {
+    this.quitCalls += 1;
+    return undefined;
+  }
+
+  on(event: string, callback: (...args: unknown[]) => void): this {
+    const listeners = this.listeners.get(event) ?? [];
+    listeners.push(callback);
+    this.listeners.set(event, listeners);
+    return this;
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+async function flushRedisCallbacks(): Promise<void> {
+  await setImmediate();
+  await setImmediate();
+}

--- a/discordjs/test/guild-settings.test.ts
+++ b/discordjs/test/guild-settings.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createGuildSettingsProvider } from "../src/guild-settings";
+
+test("Standalone Mode loads guild settings from Supabase and caches per Guild", async () => {
+  const calls: string[] = [];
+  const provider = createGuildSettingsProvider({
+    mode: "standalone",
+    loadFromSupabase: async (guildId) => {
+      calls.push(guildId);
+      return {
+        guildId,
+        musicChannelId: "music-1",
+        volumeLimit: 80,
+      };
+    },
+    loadFromConnectedCache: async () => {
+      throw new Error("Connected cache should not be used");
+    },
+  });
+
+  const first = await provider.getGuildSettings("guild-1");
+  const second = await provider.getGuildSettings("guild-1");
+
+  assert.deepEqual(first, second);
+  assert.deepEqual(calls, ["guild-1"]);
+});
+
+test("Connected Mode loads guild settings from connected settings cache", async () => {
+  const connectedCalls: string[] = [];
+  const provider = createGuildSettingsProvider({
+    mode: "connected",
+    loadFromSupabase: async () => {
+      throw new Error("Supabase should not be used in Connected Mode");
+    },
+    loadFromConnectedCache: async (guildId) => {
+      connectedCalls.push(guildId);
+      return {
+        guildId,
+        musicChannelId: "music-2",
+        volumeLimit: 90,
+      };
+    },
+  });
+
+  const settings = await provider.getGuildSettings("guild-2");
+
+  assert.deepEqual(settings, {
+    guildId: "guild-2",
+    musicChannelId: "music-2",
+    volumeLimit: 90,
+  });
+  assert.deepEqual(connectedCalls, ["guild-2"]);
+});

--- a/discordjs/test/redis-adapter.test.ts
+++ b/discordjs/test/redis-adapter.test.ts
@@ -1,0 +1,477 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createRedisAdapter } from "../src/redis-adapter";
+
+test("start rejects empty subscription patterns before creating Redis clients", async () => {
+  let createdClients = 0;
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: [],
+    createClient: () => {
+      createdClients += 1;
+      return new FakeRedisClient();
+    },
+    onMessage: async () => {},
+    onReconnect: async () => {},
+  });
+
+  await assert.rejects(
+    adapter.start(),
+    /Redis adapter requires at least one subscription pattern/,
+  );
+  assert.equal(createdClients, 0);
+});
+
+test("start creates subscriber and publisher clients, subscribes patterns, and publishes JSON", async () => {
+  const clients: FakeRedisClient[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async () => {},
+    onReconnect: async () => {},
+  });
+
+  await adapter.start();
+  await adapter.publish("bot:guild-1:state:full", { ok: true });
+
+  assert.equal(clients.length, 2);
+  assert.deepEqual(clients[0]?.psubscribeCalls, [["backend:request:state:*"]]);
+  assert.deepEqual(clients[1]?.publishCalls, [
+    ["bot:guild-1:state:full", '{"ok":true}'],
+  ]);
+}
+);
+
+test("pmessage parses JSON payloads and forwards raw strings when JSON parsing fails", async () => {
+  const clients: FakeRedisClient[] = [];
+  const messages: unknown[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async (channel, payload) => {
+      messages.push({ channel, payload });
+    },
+    onReconnect: async () => {},
+  });
+
+  await adapter.start();
+
+  clients[0]?.emit(
+    "pmessage",
+    "backend:request:state:*",
+    "backend:request:state:guild-1",
+    '{"guildId":"guild-1"}',
+  );
+  clients[0]?.emit(
+    "pmessage",
+    "backend:request:state:*",
+    "backend:request:state:guild-2",
+    "{bad-json",
+  );
+
+  assert.deepEqual(messages, [
+    {
+      channel: "backend:request:state:guild-1",
+      payload: { guildId: "guild-1" },
+    },
+    {
+      channel: "backend:request:state:guild-2",
+      payload: "{bad-json",
+    },
+  ]);
+});
+
+test("onMessage failures are logged without stopping later messages", async () => {
+  const clients: FakeRedisClient[] = [];
+  const handledChannels: string[] = [];
+  const loggedErrors: unknown[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async (channel) => {
+      handledChannels.push(channel);
+      if (channel.endsWith("guild-1")) {
+        throw new Error("handler failed");
+      }
+    },
+    onReconnect: async () => {},
+    logger: {
+      error: (_message, context) => {
+        loggedErrors.push(context);
+      },
+    },
+  });
+
+  await adapter.start();
+
+  clients[0]?.emit(
+    "pmessage",
+    "backend:request:state:*",
+    "backend:request:state:guild-1",
+    '{"secret":"not logged"}',
+  );
+  clients[0]?.emit(
+    "pmessage",
+    "backend:request:state:*",
+    "backend:request:state:guild-2",
+    "{}",
+  );
+
+  await Promise.resolve();
+
+  assert.deepEqual(handledChannels, [
+    "backend:request:state:guild-1",
+    "backend:request:state:guild-2",
+  ]);
+  assert.deepEqual(loggedErrors, [
+    {
+      channel: "backend:request:state:guild-1",
+      errorMessage: "handler failed",
+    },
+  ]);
+});
+
+test("onReconnect runs only after both Redis clients are ready following a disconnect", async () => {
+  const clients: FakeRedisClient[] = [];
+  let reconnects = 0;
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async () => {},
+    onReconnect: async () => {
+      reconnects += 1;
+    },
+  });
+
+  await adapter.start();
+
+  clients[0]?.emit("ready");
+  clients[1]?.emit("ready");
+  assert.equal(reconnects, 0);
+
+  clients[1]?.emit("close");
+  clients[0]?.emit("close");
+  clients[0]?.emit("ready");
+  assert.equal(reconnects, 0);
+
+  clients[1]?.emit("ready");
+  assert.equal(reconnects, 1);
+});
+
+test("start is idempotent and does not create duplicate Redis clients", async () => {
+  const clients: FakeRedisClient[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async () => {},
+    onReconnect: async () => {},
+  });
+
+  await adapter.start();
+  await adapter.start();
+
+  assert.equal(clients.length, 2);
+  assert.deepEqual(clients[0]?.psubscribeCalls, [["backend:request:state:*"]]);
+});
+
+test("stop before start is a no-op and publish before start reports not started", async () => {
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => new FakeRedisClient(),
+    onMessage: async () => {},
+    onReconnect: async () => {},
+  });
+
+  await adapter.stop();
+  await assert.rejects(
+    adapter.publish("bot:guild-1:state:full", {}),
+    /Redis adapter has not started/,
+  );
+});
+
+test("stop quits both clients, disables callbacks, and publish after stop reports stopped", async () => {
+  const clients: FakeRedisClient[] = [];
+  const messages: unknown[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async (channel) => {
+      messages.push(channel);
+    },
+    onReconnect: async () => {
+      messages.push("reconnect");
+    },
+  });
+
+  await adapter.start();
+  await adapter.stop();
+  await adapter.stop();
+
+  clients[0]?.emit("pmessage", "backend:request:state:*", "backend:request:state:guild-1", "{}");
+  clients[0]?.emit("close");
+  clients[0]?.emit("ready");
+  clients[1]?.emit("close");
+  clients[1]?.emit("ready");
+
+  assert.equal(clients[0]?.quitCalls, 1);
+  assert.equal(clients[1]?.quitCalls, 1);
+  assert.deepEqual(messages, []);
+  await assert.rejects(
+    adapter.publish("bot:guild-1:state:full", {}),
+    /Redis adapter has been stopped/,
+  );
+});
+
+test("adapter can start again after a clean stop", async () => {
+  const clients: FakeRedisClient[] = [];
+  const messages: unknown[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async (channel) => {
+      messages.push(channel);
+    },
+    onReconnect: async () => {},
+  });
+
+  await adapter.start();
+  await adapter.stop();
+  await adapter.start();
+  clients[0]?.emit("pmessage", "backend:request:state:*", "backend:request:state:old", "{}");
+  await adapter.publish("bot:guild-1:state:full", { ok: true });
+
+  assert.equal(clients.length, 4);
+  assert.deepEqual(messages, []);
+  assert.deepEqual(clients[2]?.psubscribeCalls, [["backend:request:state:*"]]);
+  assert.deepEqual(clients[3]?.publishCalls, [
+    ["bot:guild-1:state:full", '{"ok":true}'],
+  ]);
+});
+
+test("start cleans up both clients when psubscribe fails", async () => {
+  const clients: FakeRedisClient[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async () => {},
+    onReconnect: async () => {},
+  });
+  clients;
+
+  const originalCreateClient = (() => {
+    let count = 0;
+    return () => {
+      const client = new FakeRedisClient();
+      if (count === 0) {
+        client.psubscribeError = new Error("subscribe failed");
+      }
+      count += 1;
+      clients.push(client);
+      return client;
+    };
+  })();
+  const failingAdapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: originalCreateClient,
+    onMessage: async () => {},
+    onReconnect: async () => {},
+  });
+
+  await assert.rejects(failingAdapter.start(), /subscribe failed/);
+
+  assert.equal(clients[0]?.quitCalls, 1);
+  assert.equal(clients[1]?.quitCalls, 1);
+  await assert.rejects(
+    failingAdapter.publish("bot:guild-1:state:full", {}),
+    /Redis adapter has not started/,
+  );
+});
+
+test("start disables callbacks from clients that failed to subscribe", async () => {
+  const clients: FakeRedisClient[] = [];
+  const messages: unknown[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: (() => {
+      let count = 0;
+      return () => {
+        const client = new FakeRedisClient();
+        if (count === 0) {
+          client.psubscribeError = new Error("subscribe failed");
+        }
+        count += 1;
+        clients.push(client);
+        return client;
+      };
+    })(),
+    onMessage: async (channel) => {
+      messages.push(channel);
+    },
+    onReconnect: async () => {
+      messages.push("reconnect");
+    },
+  });
+
+  await assert.rejects(adapter.start(), /subscribe failed/);
+  clients[0]?.emit("pmessage", "backend:request:state:*", "backend:request:state:guild-1", "{}");
+  clients[0]?.emit("ready");
+  clients[1]?.emit("ready");
+
+  assert.deepEqual(messages, []);
+});
+
+test("stop attempts both quits, logs failures, then throws when cleanup fails", async () => {
+  const clients: FakeRedisClient[] = [];
+  const loggedErrors: unknown[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async () => {},
+    onReconnect: async () => {},
+    logger: {
+      error: (_message, context) => {
+        loggedErrors.push(context);
+      },
+    },
+  });
+
+  await adapter.start();
+  clients[0]!.quitError = new Error("subscriber quit failed");
+
+  await assert.rejects(adapter.stop(), /Redis adapter failed to stop cleanly/);
+
+  assert.equal(clients[0]?.quitCalls, 1);
+  assert.equal(clients[1]?.quitCalls, 1);
+  assert.deepEqual(loggedErrors, [
+    {
+      errorMessage: "subscriber quit failed",
+    },
+  ]);
+});
+
+test("Redis error events are logged without closing the adapter", async () => {
+  const clients: FakeRedisClient[] = [];
+  const loggedErrors: unknown[] = [];
+  const adapter = createRedisAdapter({
+    redisUrl: "redis://localhost:6379",
+    patterns: ["backend:request:state:*"],
+    createClient: () => {
+      const client = new FakeRedisClient();
+      clients.push(client);
+      return client;
+    },
+    onMessage: async () => {},
+    onReconnect: async () => {},
+    logger: {
+      error: (_message, context) => {
+        loggedErrors.push(context);
+      },
+    },
+  });
+
+  await adapter.start();
+  clients[0]?.emit("error", new Error("subscriber failed"));
+  await adapter.publish("bot:guild-1:state:full", null);
+
+  assert.deepEqual(loggedErrors, [
+    {
+      clientRole: "subscriber",
+      errorMessage: "subscriber failed",
+    },
+  ]);
+  assert.deepEqual(clients[1]?.publishCalls, [["bot:guild-1:state:full", "{}"]]);
+});
+
+class FakeRedisClient {
+  psubscribeCalls: string[][] = [];
+  publishCalls: Array<[string, string]> = [];
+  quitCalls = 0;
+  psubscribeError: Error | null = null;
+  quitError: Error | null = null;
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  async psubscribe(..._patterns: string[]): Promise<unknown> {
+    if (this.psubscribeError) {
+      throw this.psubscribeError;
+    }
+
+    this.psubscribeCalls.push(_patterns);
+    return undefined;
+  }
+
+  async publish(_channel: string, _message: string): Promise<unknown> {
+    this.publishCalls.push([_channel, _message]);
+    return undefined;
+  }
+
+  async quit(): Promise<unknown> {
+    this.quitCalls += 1;
+    if (this.quitError) {
+      throw this.quitError;
+    }
+
+    return undefined;
+  }
+
+  on(_event: string, _callback: (...args: unknown[]) => void): this {
+    const listeners = this.listeners.get(_event) ?? [];
+    listeners.push(_callback);
+    this.listeners.set(_event, listeners);
+    return this;
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}

--- a/discordjs/test/redis-lifecycle.test.ts
+++ b/discordjs/test/redis-lifecycle.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createRedisLifecycle } from "../src/redis-lifecycle";
+
+test("Standalone Mode does not start Redis lifecycle", async () => {
+  let starts = 0;
+  const lifecycle = createRedisLifecycle({
+    mode: "standalone",
+    startRedis: async () => {
+      starts += 1;
+    },
+    getActiveGuildIds: () => ["guild-1"],
+    publishFullState: async () => {
+      throw new Error("State should not be published in Standalone Mode");
+    },
+  });
+
+  await lifecycle.start();
+  await lifecycle.handleReconnect();
+
+  assert.equal(lifecycle.getMode(), "standalone");
+  assert.equal(starts, 0);
+});
+
+test("Connected Mode publishes full state for every active Guild on Redis reconnect", async () => {
+  let starts = 0;
+  const publishedGuilds: string[] = [];
+  const lifecycle = createRedisLifecycle({
+    mode: "connected",
+    startRedis: async () => {
+      starts += 1;
+    },
+    getActiveGuildIds: () => ["guild-1", "guild-2"],
+    publishFullState: async (guildId) => {
+      publishedGuilds.push(guildId);
+    },
+  });
+
+  await lifecycle.start();
+  await lifecycle.handleReconnect();
+
+  assert.equal(lifecycle.getMode(), "connected");
+  assert.equal(starts, 1);
+  assert.deepEqual(publishedGuilds, ["guild-1", "guild-2"]);
+});
+
+test("Connected Mode continues resyncing other Guilds when one publish fails", async () => {
+  const publishedGuilds: string[] = [];
+  const lifecycle = createRedisLifecycle({
+    mode: "connected",
+    startRedis: async () => {},
+    getActiveGuildIds: () => ["guild-1", "guild-2", "guild-3"],
+    publishFullState: async (guildId) => {
+      publishedGuilds.push(guildId);
+
+      if (guildId === "guild-2") {
+        throw new Error("publish failed");
+      }
+    },
+  });
+
+  const result = await lifecycle.handleReconnect();
+
+  assert.deepEqual(publishedGuilds, ["guild-1", "guild-2", "guild-3"]);
+  assert.deepEqual(result.failedGuildIds, ["guild-2"]);
+});

--- a/discordjs/test/runtime-mode.test.ts
+++ b/discordjs/test/runtime-mode.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { detectRuntimeMode } from "../src/runtime-mode";
+
+test("enters Standalone Mode without REDIS_URL", async () => {
+  let calls = 0;
+
+  const result = await detectRuntimeMode({
+    env: {},
+    connectRedis: async () => {
+      calls += 1;
+    },
+  });
+
+  assert.equal(result.mode, "standalone");
+  assert.equal(result.reason, "redis_url_missing");
+  assert.equal(calls, 0);
+});
+
+test("enters Connected Mode when Redis connects", async () => {
+  const calls: string[] = [];
+
+  const result = await detectRuntimeMode({
+    env: { REDIS_URL: "redis://localhost:6379" },
+    connectRedis: async (redisUrl) => {
+      calls.push(redisUrl);
+    },
+  });
+
+  assert.equal(result.mode, "connected");
+  assert.equal(result.reason, "redis_connected");
+  assert.deepEqual(calls, ["redis://localhost:6379"]);
+});
+
+test("falls back to Standalone Mode when Redis connect fails", async () => {
+  const result = await detectRuntimeMode({
+    env: { REDIS_URL: "redis://localhost:6379" },
+    connectRedis: async () => {
+      throw new Error("ECONNREFUSED");
+    },
+  });
+
+  assert.equal(result.mode, "standalone");
+  assert.equal(result.reason, "redis_unavailable");
+});
+
+test("falls back to Standalone Mode when Redis connect times out", async () => {
+  let aborted = false;
+
+  const result = await detectRuntimeMode({
+    env: { REDIS_URL: "redis://localhost:6379" },
+    timeoutMs: 10,
+    connectRedis: async (_redisUrl, signal) => {
+      await new Promise<void>((_, reject) => {
+        signal.addEventListener("abort", () => {
+          aborted = true;
+          reject(new Error("aborted"));
+        });
+      });
+    },
+  });
+
+  assert.equal(result.mode, "standalone");
+  assert.equal(result.reason, "redis_unavailable");
+  assert.equal(aborted, true);
+});

--- a/discordjs/test/state-request-handler.test.ts
+++ b/discordjs/test/state-request-handler.test.ts
@@ -1,0 +1,382 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createStateRequestHandler } from "../src/state-request-handler";
+
+test("publishes idle PlayerState for a valid state request with no runtime Guild state", async () => {
+  const publishedStates: unknown[] = [];
+  const handler = createStateRequestHandler({
+    mode: "connected",
+    getGuildSettings: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 80,
+    }),
+    getRuntimeGuildState: async () => undefined,
+    publishStateFull: async (_guildId, state) => {
+      publishedStates.push(state);
+    },
+    publishError: async () => {
+      throw new Error("Error should not be published");
+    },
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await handler.handleStateRequest("backend:request:state:guild-1", {});
+
+  assert.deepEqual(publishedStates, [
+    {
+      guildId: "guild-1",
+      botMode: "connected",
+      isPlaying: false,
+      isPaused: false,
+      volume: 80,
+      loopMode: "off",
+      position: 0,
+      currentTrack: null,
+      queue: [],
+      voiceChannelId: null,
+    },
+  ]);
+});
+
+test("publishes invalid_payload when payload guildId does not match state request channel", async () => {
+  const publishedStates: unknown[] = [];
+  const publishedErrors: unknown[] = [];
+  const handler = createStateRequestHandler({
+    mode: "connected",
+    getGuildSettings: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 100,
+    }),
+    getRuntimeGuildState: async () => undefined,
+    publishStateFull: async (_guildId, state) => {
+      publishedStates.push(state);
+    },
+    publishError: async (_guildId, error) => {
+      publishedErrors.push(error);
+    },
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await handler.handleStateRequest("backend:request:state:guild-1", {
+    guildId: "guild-2",
+  });
+
+  assert.deepEqual(publishedStates, []);
+  assert.deepEqual(publishedErrors, [
+    {
+      errorType: "invalid_payload",
+      message: "Invalid state request payload",
+      source: "redis",
+      action: "state:full",
+      guildId: "guild-1",
+      timestamp: "2026-06-01T00:00:00.000Z",
+    },
+  ]);
+});
+
+test("normalizes runtime Guild state into PlayerState", async () => {
+  const publishedStates: unknown[] = [];
+  const handler = createStateRequestHandler({
+    mode: "connected",
+    getGuildSettings: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 60,
+    }),
+    getRuntimeGuildState: async () => ({
+      currentTrack: {
+        uri: "https://example.test/current",
+        title: "",
+        artist: "",
+        thumbnailUrl: undefined,
+        durationMs: 300_000,
+        source: "YouTube",
+        requesterId: "discord-user-1",
+      },
+      queue: [
+        {
+          uri: "https://example.test/next",
+          title: "Next track",
+          artist: "Next artist",
+          thumbnailUrl: "https://example.test/thumb.jpg",
+          durationMs: -1,
+          source: "SPOTIFY",
+          requesterId: "discord-user-2",
+        },
+      ],
+      volume: 80,
+      loopMode: "unknown",
+      position: 400_000,
+      isPaused: true,
+      voiceChannelId: "voice-1",
+    }),
+    publishStateFull: async (_guildId, state) => {
+      publishedStates.push(state);
+    },
+    publishError: async () => {
+      throw new Error("Error should not be published");
+    },
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await handler.handleStateRequest("backend:request:state:guild-1", null);
+
+  assert.deepEqual(publishedStates, [
+    {
+      guildId: "guild-1",
+      botMode: "connected",
+      isPlaying: true,
+      isPaused: true,
+      volume: 60,
+      loopMode: "off",
+      position: 300_000,
+      currentTrack: {
+        uri: "https://example.test/current",
+        title: "Unknown title",
+        artist: "Unknown artist",
+        thumbnailUrl: "",
+        durationMs: 300_000,
+        source: "youtube",
+        requesterId: "discord-user-1",
+      },
+      queue: [
+        {
+          uri: "https://example.test/next",
+          title: "Next track",
+          artist: "Next artist",
+          thumbnailUrl: "https://example.test/thumb.jpg",
+          durationMs: 0,
+          source: "spotify",
+          requesterId: "discord-user-2",
+        },
+      ],
+      voiceChannelId: "voice-1",
+    },
+  ]);
+});
+
+test("publishes invalid_payload and skips state when runtime queue contains an invalid Track", async () => {
+  const publishedStates: unknown[] = [];
+  const publishedErrors: unknown[] = [];
+  const handler = createStateRequestHandler({
+    mode: "connected",
+    getGuildSettings: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 100,
+    }),
+    getRuntimeGuildState: async () => ({
+      currentTrack: null,
+      queue: [
+        {
+          title: "Missing URI",
+          artist: "Artist",
+          source: "youtube",
+          requesterId: "discord-user-1",
+        },
+      ],
+    }),
+    publishStateFull: async (_guildId, state) => {
+      publishedStates.push(state);
+    },
+    publishError: async (_guildId, error) => {
+      publishedErrors.push(error);
+    },
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await handler.handleStateRequest("backend:request:state:guild-1", {});
+
+  assert.deepEqual(publishedStates, []);
+  assert.deepEqual(publishedErrors, [
+    {
+      errorType: "invalid_payload",
+      message: "Invalid PlayerState",
+      source: "redis",
+      action: "state:full",
+      guildId: "guild-1",
+      timestamp: "2026-06-01T00:00:00.000Z",
+    },
+  ]);
+});
+
+test("publishes state with defaults before settings_error when Guild settings fail to load", async () => {
+  const events: unknown[] = [];
+  const handler = createStateRequestHandler({
+    mode: "connected",
+    getGuildSettings: async () => {
+      throw new Error("settings unavailable");
+    },
+    getRuntimeGuildState: async () => undefined,
+    publishStateFull: async (_guildId, state) => {
+      events.push({ type: "state", state });
+    },
+    publishError: async (_guildId, error) => {
+      events.push({ type: "error", error });
+    },
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await handler.handleStateRequest("backend:request:state:guild-1", {});
+
+  assert.deepEqual(events, [
+    {
+      type: "state",
+      state: {
+        guildId: "guild-1",
+        botMode: "connected",
+        isPlaying: false,
+        isPaused: false,
+        volume: 100,
+        loopMode: "off",
+        position: 0,
+        currentTrack: null,
+        queue: [],
+        voiceChannelId: null,
+      },
+    },
+    {
+      type: "error",
+      error: {
+        errorType: "settings_error",
+        message: "Failed to load Guild settings",
+        source: "supabase",
+        action: "state:full",
+        guildId: "guild-1",
+        timestamp: "2026-06-01T00:00:00.000Z",
+      },
+    },
+  ]);
+});
+
+test("publishes command_failed when runtime Guild state cannot be read", async () => {
+  const publishedStates: unknown[] = [];
+  const publishedErrors: unknown[] = [];
+  const handler = createStateRequestHandler({
+    mode: "connected",
+    getGuildSettings: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 100,
+    }),
+    getRuntimeGuildState: async () => {
+      throw new Error("runtime unavailable");
+    },
+    publishStateFull: async (_guildId, state) => {
+      publishedStates.push(state);
+    },
+    publishError: async (_guildId, error) => {
+      publishedErrors.push(error);
+    },
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await handler.handleStateRequest("backend:request:state:guild-1", {});
+
+  assert.deepEqual(publishedStates, []);
+  assert.deepEqual(publishedErrors, [
+    {
+      errorType: "command_failed",
+      message: "Failed to build PlayerState",
+      source: "redis",
+      action: "state:full",
+      guildId: "guild-1",
+      timestamp: "2026-06-01T00:00:00.000Z",
+    },
+  ]);
+});
+
+test("does nothing for state requests in Standalone Mode", async () => {
+  const handler = createStateRequestHandler({
+    mode: "standalone",
+    getGuildSettings: async () => {
+      throw new Error("Settings should not be loaded in Standalone Mode");
+    },
+    getRuntimeGuildState: async () => {
+      throw new Error("Runtime state should not be loaded in Standalone Mode");
+    },
+    publishStateFull: async () => {
+      throw new Error("State should not be published in Standalone Mode");
+    },
+    publishError: async () => {
+      throw new Error("Error should not be published in Standalone Mode");
+    },
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await handler.handleStateRequest("backend:request:state:guild-1", {});
+});
+
+test("logs and does not retry when publishing full state fails", async () => {
+  const warnings: unknown[] = [];
+  const handler = createStateRequestHandler({
+    mode: "connected",
+    getGuildSettings: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 100,
+    }),
+    getRuntimeGuildState: async () => undefined,
+    publishStateFull: async () => {
+      throw new Error("redis unavailable");
+    },
+    publishError: async () => {
+      throw new Error("Error should not be published when state publish fails");
+    },
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+    logger: {
+      warn: (_message, context) => {
+        warnings.push(context);
+      },
+    },
+  });
+
+  await handler.handleStateRequest("backend:request:state:guild-1", {});
+
+  assert.deepEqual(warnings, [
+    {
+      guildId: "guild-1",
+      errorMessage: "redis unavailable",
+    },
+  ]);
+});
+
+test("publishes invalid_payload when runtime queue is present but not an array", async () => {
+  const publishedStates: unknown[] = [];
+  const publishedErrors: unknown[] = [];
+  const handler = createStateRequestHandler({
+    mode: "connected",
+    getGuildSettings: async (guildId) => ({
+      guildId,
+      musicChannelId: null,
+      volumeLimit: 100,
+    }),
+    getRuntimeGuildState: async () => ({
+      queue: { malformed: true },
+    }),
+    publishStateFull: async (_guildId, state) => {
+      publishedStates.push(state);
+    },
+    publishError: async (_guildId, error) => {
+      publishedErrors.push(error);
+    },
+    nowIso: () => "2026-06-01T00:00:00.000Z",
+  });
+
+  await handler.handleStateRequest("backend:request:state:guild-1", {});
+
+  assert.deepEqual(publishedStates, []);
+  assert.deepEqual(publishedErrors, [
+    {
+      errorType: "invalid_payload",
+      message: "Invalid PlayerState",
+      source: "redis",
+      action: "state:full",
+      guildId: "guild-1",
+      timestamp: "2026-06-01T00:00:00.000Z",
+    },
+  ]);
+});

--- a/discordjs/tsconfig.json
+++ b/discordjs/tsconfig.json
@@ -7,9 +7,10 @@
 
     // Environment Settings
     // See also https://aka.ms/tsconfig/module
-    "module": "nodenext",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "esnext",
-    "types": [],
+    "types": ["node"],
     // For nodejs:
     // "lib": ["esnext"],
     // "types": ["node"],
@@ -35,7 +36,7 @@
     // Recommended Options
     "strict": true,
     "jsx": "react-jsx",
-    "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": false,
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary

- Adds Bot runtime-mode, guild-settings, Redis lifecycle, state request handler, transport-only Redis adapter, and bootstrap composition boundary under `discordjs/`.
- Wires Connected Mode state hydration from `backend:request:state:*` to `bot:{guildId}:state:full`.
- Keeps Standalone Mode independent from Redis and documents `Invalid Player State` in `CONTEXT.md`.
- Hardens Redis lifecycle edge cases found during review: restart after stop, failed subscribe callback isolation, and reconnect `failedGuildIds` reporting.

## Issues

- PRD: #57
- Implements: #58

## Validation

- `npm test` from `discordjs/`: 35 tests passed
- `npx tsc --noEmit` from `discordjs/`: passed

Closes #58